### PR TITLE
Simulation test - Optional Use of Vibration Method

### DIFF
--- a/lib/main_engine.py
+++ b/lib/main_engine.py
@@ -152,7 +152,8 @@ class MainEngine:
                     'suctionState',
                     'endX',
                     'endY',
-                    'endZ'
+                    'endZ',
+                    'vibrate'
                 ]
 
                 # Update configuration
@@ -208,7 +209,8 @@ class MainEngine:
                     'suctionState',
                     'endX',
                     'endY',
-                    'endZ'
+                    'endZ',
+                    'vibrate'
                 ]
 
                 # Update configuration

--- a/tools/gripper.py
+++ b/tools/gripper.py
@@ -29,6 +29,7 @@ class Gripper:
             self.gripperCloseAngle = config.get('gripperCloseAngle', -18)
             self.gripperOpenAngle = config.get('gripperOpenAngle', -3)
             self.gripperPosition = config.get('gripperPosition', 0)
+            self.vibrate = config.get('vibrate', 0)
 
             print("Configuration loaded successfully.")
         except FileNotFoundError:
@@ -68,7 +69,9 @@ G0 Z{self.zHop_mm:.2f} ; Move to zHop position for clearance
 
     def generate_gcode(self):
         """Generates the G-code injection based on the parameters from the YAML configuration."""
-        self.generate_vibration() # Call the vibration first
+        if self.vibrate:
+            print(f"Vibration argument detected {self.vibrate}\n")
+            self.generate_vibration()
 
         # Prepend gripper g-code with vibration
         self.injected_gcode += f""";-----------------------------------------------

--- a/tools/gripper_config.yaml
+++ b/tools/gripper_config.yaml
@@ -8,3 +8,4 @@ endZ: 1.0
 gripperCloseAngle: -18
 gripperOpenAngle: 45
 gripperPosition: 0
+vibrate: 1

--- a/tools/vacuum_config.yaml
+++ b/tools/vacuum_config.yaml
@@ -1,8 +1,9 @@
 zHop_mm: 100.0
-startX: 105.82
-startY: 99.59
+startX: 105.61
+startY: 100.30
 startZ: 18.90
 suctionState: 1
 endX: 140.0
 endY: 150.0
 endZ: 60.0
+vibrate: None

--- a/tools/vacuum_config.yaml
+++ b/tools/vacuum_config.yaml
@@ -1,9 +1,9 @@
 zHop_mm: 100.0
-startX: 105.61
-startY: 100.30
+startX: 108.05
+startY: 101.32
 startZ: 18.90
 suctionState: 1
 endX: 140.0
 endY: 150.0
 endZ: 60.0
-vibrate: None
+vibrate: 1

--- a/tools/vacuum_pnp.py
+++ b/tools/vacuum_pnp.py
@@ -29,6 +29,7 @@ class VacuumPnP:
             self.endX = config.get('endX', 150.0)
             self.endY = config.get('endY', 150.0)
             self.endZ = config.get('endZ', 150.0)
+            self.vibrate = config.get('vibrate', 0)
 
             print(f"Configuration file {self.config_file} loaded successfully.")
         except FileNotFoundError:
@@ -49,10 +50,11 @@ class VacuumPnP:
 
     def generate_gcode(self):
         """Generates the G-code injection based on the parameters from the YAML configuration."""
-        self.gripper_tool.generate_vibration()
-
         self.injected_gcode = "" if self.injected_gcode is None else self.injected_gcode
-        self.injected_gcode += self.gripper_tool.injected_gcode # Append Vacuum G-Code with Gripper's Vibration G-Code
+
+        if self.vibrate:
+            print(f"Vibration argument detected {self.vibrate}\n")
+            self.injected_gcode += self.gripper_tool.injected_gcode # Append Vacuum G-Code with Gripper's Vibration G-Code
 
         self.injected_gcode += f""";-----------------------------------------------
 ; VacuumPnP TOOL G CODE INJECTION START

--- a/tools/vacuum_pnp.py
+++ b/tools/vacuum_pnp.py
@@ -51,10 +51,12 @@ class VacuumPnP:
     def generate_gcode(self):
         """Generates the G-code injection based on the parameters from the YAML configuration."""
         self.injected_gcode = "" if self.injected_gcode is None else self.injected_gcode
-
+        
         if self.vibrate:
-            print(f"Vibration argument detected {self.vibrate}\n")
-            self.injected_gcode += self.gripper_tool.injected_gcode # Append Vacuum G-Code with Gripper's Vibration G-Code
+            print("Generating g-code from the gripper tool")
+            self.gripper_tool.generate_gcode()
+            print(f"Parsing it to the function yields: \n{self.gripper_tool.injected_gcode}")
+            self.injected_gcode +=  self.gripper_tool.injected_gcode # Access post g-code generation
 
         self.injected_gcode += f""";-----------------------------------------------
 ; VacuumPnP TOOL G CODE INJECTION START


### PR DESCRIPTION
In this pull request, the vibration code has been made optional. The user can now set a flag for vibration in the tool they want to use for travel. This vibration flag can be set to 0 or 1 by the user. If the value is 1, the vibration code will be prepended to the start of the injected-gcode. This means that the vibration doesn't have to always be included meaning that we can use the gripper tools to move parts without having to remove a part from the bed.